### PR TITLE
Implement availability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ script:
   - "pep8 --ignore=E501,E225,E128 amazon"
   - "sphinx-build -b html -d _build/doctrees ./docs/ _build/html"
   - nosetests --with-coverage
+after_success:
+  - coveralls
 sudo: false 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.5
 install: 
   - pip install .
   - pip install pep8 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 script: 
   - "pep8 --ignore=E501,E225,E128 amazon"
   - "sphinx-build -b html -d _build/doctrees ./docs/ _build/html"
-  - nosetests --with-coverage
+  - nosetests with-flaky --with-coverage
 after_success:
   - coveralls
 sudo: false 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
 script: 
   - "pep8 --ignore=E501,E225,E128 amazon"
   - "sphinx-build -b html -d _build/doctrees ./docs/ _build/html"
+  - nosetests --with-coverage
 sudo: false 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 script: 
   - "pep8 --ignore=E501,E225,E128 amazon"
   - "sphinx-build -b html -d _build/doctrees ./docs/ _build/html"
-  - nosetests with-flaky --with-coverage
+  - nosetests --with-flaky --with-coverage
 after_success:
   - coveralls
 sudo: false 

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -422,7 +422,8 @@ class AmazonAPI(object):
 
         return new_cart
 
-    def _check_for_cart_error(self, cart):
+    @staticmethod
+    def _check_for_cart_error(cart):
         if cart._safe_get_element('Cart.Request.Errors') is not None:
             error = cart._safe_get_element(
                 'Cart.Request.Errors.Error.Code').text
@@ -582,7 +583,7 @@ class AmazonSearch(object):
             else:
                 raise SearchException(
                     "Amazon Search Error: '{0}', '{1}'".format(code, msg))
-        if (hasattr(root.Items, 'TotalPages') and (root.Items.TotalPages == self.current_page)):
+        if hasattr(root.Items, 'TotalPages') and root.Items.TotalPages == self.current_page:
             self.is_last_page = True
         return root
 
@@ -950,7 +951,7 @@ class AmazonProduct(LXMLWrapper):
         """
         iframe = self._safe_get_element_text('CustomerReviews.IFrameURL')
         has_reviews = self._safe_get_element_text('CustomerReviews.HasReviews')
-        if has_reviews and has_reviews == 'true':
+        if has_reviews is not None and has_reviews == 'true':
             has_reviews = True
         else:
             has_reviews = False

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -1326,6 +1326,42 @@ class AmazonProduct(LXMLWrapper):
         return self._safe_get_element_text('Offers.Offer.OfferListing.AvailabilityAttributes.IsPreorder')
 
     @property
+    def availability(self):
+        """Availability
+
+        :return:
+            Availability (string).
+        """
+        return self._safe_get_element_text('Offers.Offer.OfferListing.Availability')
+
+    @property
+    def availability_type(self):
+        """AvailabilityAttributes.AvailabilityType
+
+        :return:
+            AvailabilityType (string).
+        """
+        return self._safe_get_element_text('Offers.Offer.OfferListing.AvailabilityAttributes.AvailabilityType')
+
+    @property
+    def availability_min_hours(self):
+        """AvailabilityAttributes.MinimumHours
+
+        :return:
+            MinimumHours (int).
+        """
+        return self._safe_get_element_text('Offers.Offer.OfferListing.AvailabilityAttributes.MinimumHours')
+
+    @property
+    def availability_max_hours(self):
+        """AvailabilityAttributes.MaximumHours
+
+        :return:
+            MaximumHours (int).
+        """
+        return self._safe_get_element_text('Offers.Offer.OfferListing.AvailabilityAttributes.MaximumHours')
+
+    @property
     def detail_page_url(self):
         """DetailPageURL.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==1.1.3
 coverage
 coveralls
+flaky

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 Sphinx==1.1.3
+coverage
+coveralls

--- a/tests.py
+++ b/tests.py
@@ -417,12 +417,46 @@ class TestAmazonApi(unittest.TestCase):
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_is_preorder(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
-        assert_true(product.is_preorder == '1')
+        assert_equal(product.is_preorder, '1')
 
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_detail_page_url(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_true(product.detail_page_url.startswith('https://www.amazon.com/%C3%B7-Deluxe-Ed-Sheeran/dp/B01NBTSVDN'))
+
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_availability(self):
+        product = self.amazon.lookup(ItemId="B01CD5VC92")
+        assert_equals(product.availability, 'Usually ships in 24 hours')
+
+        product = self.amazon.lookup(ItemId="1491914254") # pre-order book
+        assert_equals(product.availability, 'Not yet published')
+
+        product = self.amazon.lookup(ItemId="B000SML2BQ") # late availability
+        assert_equals(product.availability, 'Usually ships in 3 to 6 weeks')
+
+        product = self.amazon.lookup(ItemId="B01LTHP2ZK") # unavailable 
+        assert_true(product.availability is None)
+
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_availability_type(self):
+        product = self.amazon.lookup(ItemId="B01CD5VC92")
+        assert_equals(product.availability_type, 'now')
+
+        product = self.amazon.lookup(ItemId="1491914254") # pre-order book
+        assert_equals(product.availability_type, 'now')
+
+        product = self.amazon.lookup(ItemId="B000SML2BQ") # late availability
+        assert_equals(product.availability_type, 'now')
+
+        product = self.amazon.lookup(ItemId="B01LTHP2ZK") # unavailable
+        assert_true(product.availability_type is None)
+
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_availability_min_max_hours(self):
+        product = self.amazon.lookup(ItemId="B01CD5VC92")
+        assert_equals(product.availability_min_hours, '0')
+        assert_equals(product.availability_max_hours, '0')
 
 
     def test_kwargs(self):

--- a/tests.py
+++ b/tests.py
@@ -417,7 +417,7 @@ class TestAmazonApi(unittest.TestCase):
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_is_preorder(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
-        assert_equal(product.is_preorder, '1')
+        assert_equals(product.is_preorder, '1')
 
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_detail_page_url(self):

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,9 @@
 import unittest
 
 from nose.tools import assert_equals, assert_true, assert_false, assert_raises
+from flaky import flaky
 
+import time
 import datetime
 from amazon.api import (AmazonAPI,
                         CartException,
@@ -65,6 +67,10 @@ def cache_clear():
     global CACHE
     CACHE = {}
 
+def delay_rerun():
+    time.sleep(3)
+    return True
+
 
 class TestAmazonApi(unittest.TestCase):
     """Test Amazon API
@@ -92,6 +98,7 @@ class TestAmazonApi(unittest.TestCase):
             MaxQPS=0.5
         )
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_lookup(self):
         """Test Product Lookup.
 
@@ -118,6 +125,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(product.browse_nodes[0].id, 2642129011)
         assert_equals(product.browse_nodes[0].name, 'eBook Readers')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_lookup_nonexistent_asin(self):
         """Test Product Lookup with a nonexistent ASIN.
 
@@ -125,6 +133,7 @@ class TestAmazonApi(unittest.TestCase):
         """
         assert_raises(AsinNotFound, self.amazon.lookup, ItemId="ABCD1234")
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_bulk_lookup(self):
         """Test Baulk Product Lookup.
 
@@ -137,6 +146,7 @@ class TestAmazonApi(unittest.TestCase):
         for i, product in enumerate(products):
             assert_equals(asins[i], product.asin)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_lookup_bulk(self):
         """Test Bulk Product Lookup.
 
@@ -149,6 +159,7 @@ class TestAmazonApi(unittest.TestCase):
         for i, product in enumerate(products):
             assert_equals(asins[i], product.asin)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_lookup_bulk_empty(self):
         """Test Bulk Product Lookup With No Results.
 
@@ -160,6 +171,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(type(products), list)
         assert_equals(len(products), 0)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search(self):
         """Test Product Search.
 
@@ -174,6 +186,7 @@ class TestAmazonApi(unittest.TestCase):
         else:
             assert_true(False, 'No search results returned.')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search_n(self):
         """Test Product Search N.
 
@@ -187,6 +200,7 @@ class TestAmazonApi(unittest.TestCase):
         )
         assert_equals(len(products), 1)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search_iterate_pages(self):
         products = self.amazon.search(Keywords='internet of things oreilly',
                                       SearchIndex='Books')
@@ -200,6 +214,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_true(products.is_last_page)
         assert_true(products.current_page == 8)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search_no_results(self):
         """Test Product Search with no results.
 
@@ -219,6 +234,7 @@ class TestAmazonApi(unittest.TestCase):
         )
         assert_equals(amazon.api.Region, "US")
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search_amazon_uk(self):
         """Test Poduct Search on Amazon UK.
 
@@ -241,6 +257,7 @@ class TestAmazonApi(unittest.TestCase):
         is_gbp = 'GBP' in currencies
         assert_true(is_gbp, "Currency is not GBP, cannot be Amazon UK, though")
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_similarity_lookup(self):
         """Test Similarity Lookup.
 
@@ -249,6 +266,7 @@ class TestAmazonApi(unittest.TestCase):
         products = self.amazon.similarity_lookup(ItemId=TEST_ASIN)
         assert_true(len(products) > 5)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_product_attributes(self):
         """Test Product Attributes.
 
@@ -258,6 +276,7 @@ class TestAmazonApi(unittest.TestCase):
         for attribute in PRODUCT_ATTRIBUTES:
             getattr(product, attribute)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_browse_node_lookup(self):
         """Test Browse Node Lookup.
 
@@ -269,6 +288,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(bn.name, 'eBook Readers')
         assert_equals(bn.is_category_root, False)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_obscure_date(self):
         """Test Obscure Date Formats
 
@@ -279,6 +299,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(product.publication_date.month, 5)
         assert_true(isinstance(product.publication_date, datetime.date))
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_single_creator(self):
         """Test a product with a single creator
         """
@@ -287,6 +308,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(creators[u"Jonathan Davis"], u"Narrator")
         assert_equals(len(creators.values()), 2)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_multiple_creators(self):
         """Test a product with multiple creators
         """
@@ -296,12 +318,14 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(creators[u"Colin Azariah-Kribbs"], u"Editor")
         assert_equals(len(creators.values()), 2)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_no_creators(self):
         """Test a product with no creators
         """
         product = self.amazon.lookup(ItemId="8420658537")
         assert_false(product.creators)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_single_editorial_review(self):
         product = self.amazon.lookup(ItemId="1930846258")
         expected = u'In the title piece, Alan Turing'
@@ -309,6 +333,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(product.editorial_review, product.editorial_reviews[0])
         assert_equals(len(product.editorial_reviews), 1)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_multiple_editorial_reviews(self):
         product = self.amazon.lookup(ItemId="B000FBJCJE")
         expected = u'<b>One of <i>Time</i>'
@@ -321,6 +346,7 @@ class TestAmazonApi(unittest.TestCase):
 
         assert_equals(len(product.editorial_reviews), 3)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_languages_english(self):
         """Test Language Data
 
@@ -330,6 +356,7 @@ class TestAmazonApi(unittest.TestCase):
         assert_true('english' in product.languages)
         assert_equals(len(product.languages), 1)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_languages_spanish(self):
         """Test Language Data
 
@@ -354,10 +381,12 @@ class TestAmazonApi(unittest.TestCase):
                            _AMAZON_ASSOC_TAG, Region='UK')
         assert_equals(amazon.region, 'UK')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_is_adult(self):
         product = self.amazon.lookup(ItemId="B01E7P9LEE")
         assert_true(product.is_adult is not None)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_product_group(self):
         product = self.amazon.lookup(ItemId="B01LXM0S25")
         assert_equals(product.product_group, 'DVD')
@@ -365,26 +394,32 @@ class TestAmazonApi(unittest.TestCase):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.product_group, 'Digital Music Album')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_product_type_name(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.product_type_name, 'DOWNLOADABLE_MUSIC_ALBUM')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_formatted_price(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.formatted_price, '$12.49')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_running_time(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.running_time, '494')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_studio(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.studio, 'Atlantic Records UK')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_is_preorder(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_true(product.is_preorder == '1')
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_detail_page_url(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_true(product.detail_page_url.startswith('https://www.amazon.com/%C3%B7-Deluxe-Ed-Sheeran/dp/B01NBTSVDN'))
@@ -394,6 +429,7 @@ class TestAmazonApi(unittest.TestCase):
         amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,
                            _AMAZON_ASSOC_TAG, MaxQPS=0.7)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_images(self):
         """Test images property
 

--- a/tests.py
+++ b/tests.py
@@ -67,7 +67,7 @@ def cache_clear():
     global CACHE
     CACHE = {}
 
-def delay_rerun():
+def delay_rerun(*args):
     time.sleep(3)
     return True
 

--- a/tests.py
+++ b/tests.py
@@ -10,21 +10,22 @@ from amazon.api import (AmazonAPI,
                         AmazonSearch,
                         AsinNotFound)
 
-try:
+_AMAZON_ACCESS_KEY = None
+_AMAZON_SECRET_KEY = None
+_AMAZON_ASSOC_TAG = None
+
+import os
+if 'AMAZON_ACCESS_KEY' in os.environ and 'AMAZON_SECRET_KEY' in os.environ and 'AMAZON_ASSOC_TAG' in os.environ:
+    _AMAZON_ACCESS_KEY = os.environ['AMAZON_ACCESS_KEY']
+    _AMAZON_SECRET_KEY = os.environ['AMAZON_SECRET_KEY']
+    _AMAZON_ASSOC_TAG = os.environ['AMAZON_ASSOC_TAG']
+else:
     from test_settings import (AMAZON_ACCESS_KEY,
                                AMAZON_SECRET_KEY,
                                AMAZON_ASSOC_TAG)
     _AMAZON_ACCESS_KEY = AMAZON_ACCESS_KEY
     _AMAZON_SECRET_KEY = AMAZON_SECRET_KEY
     _AMAZON_ASSOC_TAG = AMAZON_ASSOC_TAG
-except ModuleNotFoundError:
-    import os
-    if 'AMAZON_ACCESS_KEY' not in os.environ or 'AMAZON_SECRET_KEY' not in os.environ or 'AMAZON_ASSOC_TAG' not in os.environ:
-        raise Exception('AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY and AMAZON_ASSOC_TAG are not configured.')
-
-    _AMAZON_ACCESS_KEY = os.environ['AMAZON_ACCESS_KEY']
-    _AMAZON_SECRET_KEY = os.environ['AMAZON_SECRET_KEY']
-    _AMAZON_ASSOC_TAG = os.environ['AMAZON_ASSOC_TAG']
 
 
 TEST_ASIN = "0312098286"

--- a/tests.py
+++ b/tests.py
@@ -9,9 +9,22 @@ from amazon.api import (AmazonAPI,
                         SearchException,
                         AmazonSearch,
                         AsinNotFound)
-from test_settings import (AMAZON_ACCESS_KEY,
-                           AMAZON_SECRET_KEY,
-                           AMAZON_ASSOC_TAG)
+
+try:
+    from test_settings import (AMAZON_ACCESS_KEY,
+                               AMAZON_SECRET_KEY,
+                               AMAZON_ASSOC_TAG)
+    _AMAZON_ACCESS_KEY = AMAZON_ACCESS_KEY
+    _AMAZON_SECRET_KEY = AMAZON_SECRET_KEY
+    _AMAZON_ASSOC_TAG = AMAZON_ASSOC_TAG
+except ModuleNotFoundError:
+    import os
+    if 'AMAZON_ACCESS_KEY' not in os.environ or 'AMAZON_SECRET_KEY' not in os.environ or 'AMAZON_ASSOC_TAG' not in os.environ:
+        raise Exception('AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY and AMAZON_ASSOC_TAG are not configured.')
+
+    _AMAZON_ACCESS_KEY = os.environ['AMAZON_ACCESS_KEY']
+    _AMAZON_SECRET_KEY = os.environ['AMAZON_SECRET_KEY']
+    _AMAZON_ASSOC_TAG = os.environ['AMAZON_ASSOC_TAG']
 
 
 TEST_ASIN = "0312098286"
@@ -70,9 +83,9 @@ class TestAmazonApi(unittest.TestCase):
         Are imported from a custom file named: 'test_settings.py'
         """
         self.amazon = AmazonAPI(
-            AMAZON_ACCESS_KEY,
-            AMAZON_SECRET_KEY,
-            AMAZON_ASSOC_TAG,
+            _AMAZON_ACCESS_KEY,
+            _AMAZON_SECRET_KEY,
+            _AMAZON_ASSOC_TAG,
             CacheReader=cache_reader,
             CacheWriter=cache_writer,
             MaxQPS=0.5
@@ -199,9 +212,9 @@ class TestAmazonApi(unittest.TestCase):
     def test_amazon_api_defaults_to_US(self):
         """Test Amazon API defaults to the US store."""
         amazon = AmazonAPI(
-            AMAZON_ACCESS_KEY,
-            AMAZON_SECRET_KEY,
-            AMAZON_ASSOC_TAG
+            _AMAZON_ACCESS_KEY,
+            _AMAZON_SECRET_KEY,
+            _AMAZON_ASSOC_TAG
         )
         assert_equals(amazon.api.Region, "US")
 
@@ -213,9 +226,9 @@ class TestAmazonApi(unittest.TestCase):
         results were returned.
         """
         amazon = AmazonAPI(
-            AMAZON_ACCESS_KEY,
-            AMAZON_SECRET_KEY,
-            AMAZON_ASSOC_TAG,
+            _AMAZON_ACCESS_KEY,
+            _AMAZON_SECRET_KEY,
+            _AMAZON_ASSOC_TAG,
             region="UK"
         )
         assert_equals(amazon.api.Region, "UK", "Region has not been set to UK")
@@ -326,18 +339,18 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(len(product.languages), 1)
 
     def test_region(self):
-        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY,
-                           AMAZON_ASSOC_TAG)
+        amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,
+                           _AMAZON_ASSOC_TAG)
         assert_equals(amazon.region, 'US')
 
         # old 'region' parameter
-        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY,
-                           AMAZON_ASSOC_TAG, region='UK')
+        amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,
+                           _AMAZON_ASSOC_TAG, region='UK')
         assert_equals(amazon.region, 'UK')
 
         # kwargs method
-        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY,
-                           AMAZON_ASSOC_TAG, Region='UK')
+        amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,
+                           _AMAZON_ASSOC_TAG, Region='UK')
         assert_equals(amazon.region, 'UK')
 
     def test_is_adult(self):
@@ -377,8 +390,8 @@ class TestAmazonApi(unittest.TestCase):
 
 
     def test_kwargs(self):
-        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY,
-                           AMAZON_ASSOC_TAG, MaxQPS=0.7)
+        amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,
+                           _AMAZON_ASSOC_TAG, MaxQPS=0.7)
 
     def test_images(self):
         """Test images property
@@ -395,9 +408,9 @@ class TestAmazonApi(unittest.TestCase):
 class TestAmazonCart(unittest.TestCase):
     def setUp(self):
         self.amazon = AmazonAPI(
-            AMAZON_ACCESS_KEY,
-            AMAZON_SECRET_KEY,
-            AMAZON_ASSOC_TAG,
+            _AMAZON_ACCESS_KEY,
+            _AMAZON_SECRET_KEY,
+            _AMAZON_ASSOC_TAG,
             CacheReader=cache_reader,
             CacheWriter=cache_writer,
             MaxQPS=0.5


### PR DESCRIPTION
Implemented a few properties to access availability related information.

Additionally, some enhancements for Travis CI were done. Unit tests are now run on Travis CI. Due to Amazon frequently blocking access when triggering too many requests (error `503`), [flaky](https://github.com/box/flaky) was added.

In order to run the tests on Travis without committing Amazon credentials, I added the ability to pass the credentials via environment variables, which can be configured on the Travis settings page.

Furthermore, code coverage is also measured and reported to [coveralls.io](https://coveralls.io/).

`implement-availability`:
[![Build Status](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api.svg?branch=implement-availability)](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api)

`master`:
[![Build Status](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api.svg?branch=master)](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api)